### PR TITLE
Add Telegram Instant View friendly metadata for blog posts

### DIFF
--- a/layouts/partials/head-additions.html
+++ b/layouts/partials/head-additions.html
@@ -1,17 +1,53 @@
 {{- if .IsPage -}}
+{{- $description := .Description | default .Summary | plainify -}}
+{{- $title := .Title | plainify -}}
+{{- $image := "" -}}
+{{- with .Params.image }}{{- $image = . | absURL -}}{{- end -}}
+{{- if and (eq $image "") .Params.featured_image }}{{- $image = .Params.featured_image | absURL -}}{{- end -}}
+
 <meta property="og:type" content="article">
 <meta property="og:url" content="{{ .Permalink }}">
-<meta property="og:title" content="{{ .Title }}">
-<meta property="og:description" content="{{ .Description | default .Summary }}">
-<meta property="og:site_name" content="Mauricio Junio">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ .Title }}">
-<meta name="twitter:description" content="{{ .Description | default .Summary }}">
-{{- if .Params.image }}
-<meta property="og:image" content="{{ .Params.image | absURL }}">
-<meta name="twitter:image" content="{{ .Params.image | absURL }}">
-{{- else if .Params.featured_image }}
-<meta property="og:image" content="{{ .Params.featured_image | absURL }}">
-<meta name="twitter:image" content="{{ .Params.featured_image | absURL }}">
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:description" content="{{ $description }}">
+<meta property="og:site_name" content="{{ site.Title }}">
+{{- with $image }}
+<meta property="og:image" content="{{ . }}">
+<meta name="twitter:image" content="{{ . }}">
 {{- end }}
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ $description }}">
+
+<meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
+{{- with .Lastmod }}
+<meta property="article:modified_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}">
+{{- end }}
+{{- range .Params.tags }}
+<meta property="article:tag" content="{{ . }}">
+{{- end }}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ $title | jsonify }},
+  "description": {{ $description | jsonify }},
+  "url": {{ .Permalink | jsonify }},
+  "mainEntityOfPage": {{ .Permalink | jsonify }},
+  "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+  "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+  "author": {
+    "@type": "Person",
+    "name": {{ .Params.author | default site.Params.author | default site.Title | jsonify }}
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": {{ site.Title | jsonify }}
+  }
+  {{- with $image }},
+  "image": {{ . | jsonify }}
+  {{- end }}
+}
+</script>
 {{- end -}}


### PR DESCRIPTION
### Motivation
- Make article pages more reliably parseable by Telegram Instant View and other link preview parsers. 
- Provide consistent Open Graph and Twitter fields with safe fallbacks for title, description, and image. 
- Expose article semantics (publish/modified timestamps and tags) and structured data so automated systems can interpret posts correctly.

### Description
- Updated `layouts/partials/head-additions.html` to compute normalized variables ` $title`, `$description`, and `$image` with fallbacks to `.Params.image`, `.Params.featured_image`, `.Summary`, and `.Description`.
- Replaced inline OG/Twitter uses of `.Title`/`.Description` with the normalized values and added optional `og:image`/`twitter:image` when available.
- Added article metadata tags `article:published_time`, `article:modified_time`, and `article:tag` for each page.
- Injected `BlogPosting` JSON-LD including `headline`, `description`, `url`, `datePublished`, `dateModified`, `author`, `publisher`, and optional `image`.

### Testing
- Attempted a local build with `hugo --gc --minify`, which failed in this environment because `hugo` is not installed (`command not found`).
- Performed a static template review and file update, and the change was committed with `git commit` which succeeded.
- No CI build was run here; changes are confined to the local layout partial and do not modify `themes/ananke/` or generated output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc06b5374832d9e5a49ac496d5b72)